### PR TITLE
Skip nil params to Merge1D

### DIFF
--- a/src/Array/Merge1D.lua
+++ b/src/Array/Merge1D.lua
@@ -5,6 +5,11 @@ local function Merge1D<T>(...: {T}): {T}
 
     for SubArrayIndex = 2, select("#", ...) do
         local SubArray = select(SubArrayIndex, ...)
+
+        if (not SubArray) then
+            continue
+        end
+
         local Size = #SubArray
         table.move(SubArray, 1, Size, Index, Result)
         Index += Size

--- a/src/Map/Merge1D.lua
+++ b/src/Map/Merge1D.lua
@@ -3,6 +3,12 @@ local function Merge1D(...)
     local Result = {}
 
     for Index = 1, select("#", ...) do
+        local Table = select(Index, ...)
+
+        if (not Table) then
+            continue
+        end
+
         for Key, Value in select(Index, ...) do
             Result[Key] = Value
         end


### PR DESCRIPTION
`select("#", ...)` also shows arguments that are explicitly `nil`, this change skips those (some functions may return a table or nil, this allows it to skip over those rather than error)